### PR TITLE
Add analytics tracking and response data collection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,8 @@ Auto-generated from all feature plans. Last updated: 2026-02-27
 - localStorage (user progress), file-based JSON (question banks) (007-fix-mobile-mode)
 - JavaScript ES2022+ (ES modules), HTML5, CSS3 + nanostores 1.1, Vite 7.3, deck.gl 9.2, KaTeX (CDN), pako (new — for deflate compression) (008-shareable-map-links)
 - localStorage (user progress), URL query parameter (shared state) (008-shareable-map-links)
+- JavaScript ES2022+ (ES modules), HTML5, CSS3 + nanostores 1.1, Vite 7.3, pako (existing — for token deflate), GoatCounter (external CDN script) (010-analytics-data-collection)
+- localStorage (opt-out preference), Google Sheets (collection records via GAS) (010-analytics-data-collection)
 
 - JavaScript ES2022+ (ES modules), HTML5, CSS3 + nanostores 1.1.0, Vite 7.3.1, Canvas 2D API, KaTeX (CDN) (003-ux-bugfix-cleanup)
 
@@ -31,9 +33,9 @@ npm test && npm run lint
 JavaScript ES2022+ (ES modules), HTML5, CSS3: Follow standard conventions
 
 ## Recent Changes
+- 010-analytics-data-collection: Added JavaScript ES2022+ (ES modules), HTML5, CSS3 + nanostores 1.1, Vite 7.3, pako (existing — for token deflate), GoatCounter (external CDN script)
 - 008-shareable-map-links: Added JavaScript ES2022+ (ES modules), HTML5, CSS3 + nanostores 1.1, Vite 7.3, deck.gl 9.2, KaTeX (CDN), pako (new — for deflate compression)
 - 007-fix-mobile-mode: Added JavaScript ES2022+ (ES modules), HTML5, CSS3 + nanostores 1.1, Vite 7.3, deck.gl 9.2, KaTeX (CDN)
-- 006-performance-and-ux-refinement: Added JavaScript ES2022+ (ES modules), HTML5, CSS3 + nanostores 1.1, Vite 7.3, Canvas 2D API, KaTeX (CDN), deck.gl 9.2
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/index.html
+++ b/index.html
@@ -994,7 +994,7 @@
                     </p>
                     <p>
                         <i class="fa-solid fa-graduation-cap" style="margin-right: 8px;"></i>
-                        Click <a href="#" id="landing-info-link" style="white-space:nowrap;"><i class="fa-solid fa-circle-info" style="margin: 0 2px;"></i> info</a> in the upper right to learn more, or read our <a href="https://osf.io/preprints/psyarxiv/dh3q2" target="_blank" rel="noopener">research paper</a>.
+                        Click <a href="#" id="landing-info-link" style="white-space:nowrap;"><i class="fa-solid fa-circle-info" style="margin: 0 2px;"></i> info</a> in the upper right to learn more, or read our <a href="https://www.doi.org/10.1038/s41467-026-69746-w" target="_blank" rel="noopener">research paper</a>.
                     </p>
 
                     <button id="landing-start-btn" class="landing-start-btn">Map my knowledge!</button>
@@ -1079,9 +1079,7 @@
             </p>
             <p style="line-height: 1.7; margin-bottom: 1rem; font-size: 0.9rem;">
                 <strong>Research paper:</strong>
-                <a href="https://osf.io/preprints/psyarxiv/dh3q2" target="_blank" rel="noopener">
-                    Text embedding models yield detailed conceptual knowledge maps derived from short multiple-choice quizzes
-                </a>
+                Fitzpatrick PC, Heusser AC, Manning JR (2026). Text embedding models yield detailed conceptual knowledge maps derived from short multiple-choice quizzes. <em>Nature Communications</em>: <a href="https://www.doi.org/10.1038/s41467-026-69746-w" target="_blank" rel="noopener">10.1038/s41467-026-69746-w</a>.
             </p>
             <p style="line-height: 1.7; margin-bottom: 1rem; font-size: 0.9rem;">
                 <strong>Source code:</strong>

--- a/index.html
+++ b/index.html
@@ -1125,9 +1125,9 @@
                 No personal information is stored. You can opt out at any time using the toggle below.
             </p>
             <div id="collect-toggle-wrap" style="display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.25rem;">
-                <div id="collect-toggle-track" role="switch" aria-checked="true" aria-label="Share anonymized responses" tabindex="0"
-                     style="position:relative;width:36px;height:20px;background:var(--color-primary,#00693e);border-radius:10px;cursor:pointer;transition:background 0.2s;flex-shrink:0;">
-                    <div id="collect-toggle-thumb" style="position:absolute;top:2px;left:18px;width:16px;height:16px;background:#fff;border-radius:50%;transition:left 0.2s;box-shadow:0 1px 3px rgba(0,0,0,0.2);"></div>
+                <div id="collect-toggle-track" role="switch" aria-checked="false" aria-label="Share anonymized responses" tabindex="0"
+                     style="position:relative;width:36px;height:20px;background:var(--color-text-muted,#94a3b8);border-radius:10px;cursor:pointer;transition:background 0.2s;flex-shrink:0;">
+                    <div id="collect-toggle-thumb" style="position:absolute;top:2px;left:2px;width:16px;height:16px;background:#fff;border-radius:50%;transition:left 0.2s;box-shadow:0 1px 3px rgba(0,0,0,0.2);"></div>
                 </div>
                 <span style="font-size:0.8rem;color:var(--color-text-muted);">Share anonymized responses</span>
             </div>

--- a/index.html
+++ b/index.html
@@ -1116,9 +1116,21 @@
                 Click on the correct response to answer each question. Use the number keys 1&ndash;4 for quick answers.
             </p>
             <p style="font-size: 0.8rem; color: var(--color-text-muted);">
-                All computation runs in your browser. No data is sent to any server.
+                All computation runs in your browser.
                 Your progress is saved locally and can be exported or reset at any time.
             </p>
+            <h3 style="margin-top: 1rem; margin-bottom: 0.5rem; font-size: 0.9rem; color: var(--color-primary);">Data Collection</h3>
+            <p style="line-height: 1.7; margin-bottom: 0.5rem; font-size: 0.85rem;">
+                We collect anonymized quiz responses (answers only) to help improve our system.
+                No personal information is stored. You can opt out at any time using the toggle below.
+            </p>
+            <div id="collect-toggle-wrap" style="display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.25rem;">
+                <div id="collect-toggle-track" role="switch" aria-checked="true" aria-label="Share anonymized responses" tabindex="0"
+                     style="position:relative;width:36px;height:20px;background:var(--color-primary,#00693e);border-radius:10px;cursor:pointer;transition:background 0.2s;flex-shrink:0;">
+                    <div id="collect-toggle-thumb" style="position:absolute;top:2px;left:18px;width:16px;height:16px;background:#fff;border-radius:50%;transition:left 0.2s;box-shadow:0 1px 3px rgba(0,0,0,0.2);"></div>
+                </div>
+                <span style="font-size:0.8rem;color:var(--color-text-muted);">Share anonymized responses</span>
+            </div>
             <p style="font-size: 0.75rem; color: var(--color-text-muted); opacity: 0.8; margin-top: 0.75rem; padding-top: 0.75rem; border-top: 1px solid var(--color-border);">
                 <strong>Note:</strong> The knowledge estimates assume that your responses reflect genuine effort.
                 Randomly clicking through questions without thinking will generate estimates
@@ -1220,5 +1232,9 @@
 
     <!-- Vite Entry Point -->
     <script type="module" src="/src/app.js"></script>
+
+    <!-- GoatCounter analytics (cookie-free, privacy-respecting) -->
+    <script data-goatcounter="https://context-lab.goatcounter.com/count"
+            async src="//gc.zgo.at/count.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1079,7 +1079,7 @@
             </p>
             <p style="line-height: 1.7; margin-bottom: 1rem; font-size: 0.9rem;">
                 <strong>Research paper:</strong>
-                Fitzpatrick PC, Heusser AC, Manning JR (2026). Text embedding models yield detailed conceptual knowledge maps derived from short multiple-choice quizzes. <em>Nature Communications</em>: <a href="https://www.doi.org/10.1038/s41467-026-69746-w" target="_blank" rel="noopener">10.1038/s41467-026-69746-w</a>.
+                Fitzpatrick PC, Heusser AC, Manning JR (2026). Text embedding models yield detailed conceptual knowledge maps derived from short multiple-choice quizzes. <em>Nature Communications</em>, 17(2055): <a href="https://www.doi.org/10.1038/s41467-026-69746-w" target="_blank" rel="noopener">10.1038/s41467-026-69746-w</a>.
             </p>
             <p style="line-height: 1.7; margin-bottom: 1rem; font-size: 0.9rem;">
                 <strong>Source code:</strong>

--- a/scripts/decode-tokens.js
+++ b/scripts/decode-tokens.js
@@ -120,7 +120,6 @@ function parseCSVInput(content) {
       session_id: parts[1],
       token: parts[2],
       response_count: parseInt(parts[3], 10) || 0,
-      domain: parts[4] || 'all',
     });
   }
   return records;
@@ -175,9 +174,9 @@ async function main() {
       decoded.push({
         session_id: record.session_id,
         timestamp: record.timestamp,
-        domain: record.domain,
         question_index: entry.index,
         question_id: q?.id || `unknown_${entry.index}`,
+        domain: q?.domain_ids?.[0] || 'unknown',
         question_text: q?.question_text || '',
         correct_answer: q ? q.options?.[q.correct_answer] || '' : '',
         is_correct: entry.is_correct,

--- a/scripts/decode-tokens.js
+++ b/scripts/decode-tokens.js
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+
+/**
+ * Offline token decoder for Knowledge Mapper response collection.
+ *
+ * Reads tokens from a CSV or JSON file (exported from the Google Sheet)
+ * and decodes each into structured response data.
+ *
+ * Usage:
+ *   node scripts/decode-tokens.js --input tokens.csv --format csv > decoded.csv
+ *   node scripts/decode-tokens.js --input tokens.json --format json > decoded.json
+ *
+ * Input CSV format (from Google Sheet):
+ *   Timestamp, Session ID, Token, Response Count, Domain
+ *
+ * Output includes: session_id, timestamp, question_id, is_correct, is_skipped
+ */
+
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { inflate } from 'pako';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ── Inline token decoder (avoids importing browser-only modules) ───────
+
+function base64urlToBytes(str) {
+  const b64 = str.replace(/-/g, '+').replace(/_/g, '/');
+  const pad = (4 - (b64.length % 4)) % 4;
+  const padded = b64 + '='.repeat(pad);
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+function decodeTokenRaw(base64urlString) {
+  try {
+    const compressed = base64urlToBytes(base64urlString);
+    const bytes = inflate(compressed, { raw: true });
+    if (bytes.length < 3) return null;
+
+    const version = bytes[0];
+    const count = (bytes[1] << 8) | bytes[2];
+    const entries = [];
+
+    for (let i = 0; i < count; i++) {
+      const offset = 3 + i * 3;
+      if (offset + 2 >= bytes.length) break;
+      const index = (bytes[offset] << 8) | bytes[offset + 1];
+      const value = bytes[offset + 2];
+      entries.push({
+        index,
+        is_correct: value === 2,
+        is_skipped: value === 1,
+      });
+    }
+
+    return { version, entries };
+  } catch (err) {
+    console.error('[decoder] Failed to decode token:', err.message);
+    return null;
+  }
+}
+
+// ── Question index builder ─────────────────────────────────────────────
+
+async function loadQuestionIndex() {
+  // Load all domain bundles and merge questions (matching browser boot flow)
+  const dataDir = resolve(__dirname, '..', 'data', 'domains');
+  const { readdirSync } = await import('fs');
+  const files = readdirSync(dataDir).filter(f => f.endsWith('.json') && f !== 'all.json');
+
+  const allQuestions = new Map();
+
+  // Load all.json first (boot bundle with 50 questions)
+  const allBundle = JSON.parse(readFileSync(resolve(dataDir, 'all.json'), 'utf-8'));
+  for (const q of allBundle.questions) allQuestions.set(q.id, q);
+
+  // Load all domain bundles to get the full 2500 questions
+  for (const file of files) {
+    try {
+      const bundle = JSON.parse(readFileSync(resolve(dataDir, file), 'utf-8'));
+      if (bundle.questions) {
+        for (const q of bundle.questions) allQuestions.set(q.id, q);
+      }
+    } catch { /* skip malformed files */ }
+  }
+
+  // Sort deterministically — must match buildIndex() in question-index.js exactly
+  // (uses < / > comparison, NOT localeCompare)
+  const sorted = [...allQuestions.values()].sort((a, b) => {
+    const da = (a.domain_ids?.[0] || '');
+    const db = (b.domain_ids?.[0] || '');
+    if (da < db) return -1;
+    if (da > db) return 1;
+    if (a.id < b.id) return -1;
+    if (a.id > b.id) return 1;
+    return 0;
+  });
+
+  const indexToQuestion = new Map();
+  sorted.forEach((q, i) => indexToQuestion.set(i, q));
+
+  return indexToQuestion;
+}
+
+// ── Input parsing ──────────────────────────────────────────────────────
+
+function parseCSVInput(content) {
+  const lines = content.trim().split('\n');
+  // Skip header row
+  const records = [];
+  for (let i = 1; i < lines.length; i++) {
+    const parts = lines[i].split(',').map(s => s.trim());
+    if (parts.length < 3) continue;
+    records.push({
+      timestamp: parts[0],
+      session_id: parts[1],
+      token: parts[2],
+      response_count: parseInt(parts[3], 10) || 0,
+      domain: parts[4] || 'all',
+    });
+  }
+  return records;
+}
+
+function parseJSONInput(content) {
+  const data = JSON.parse(content);
+  return Array.isArray(data) ? data : [data];
+}
+
+// ── Main ───────────────────────────────────────────────────────────────
+
+async function main() {
+  const args = process.argv.slice(2);
+  let inputFile = null;
+  let outputFormat = 'csv';
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--input' && args[i + 1]) inputFile = args[++i];
+    else if (args[i] === '--format' && args[i + 1]) outputFormat = args[++i];
+    else if (args[i] === '--help') {
+      console.log('Usage: node scripts/decode-tokens.js --input <file> --format <csv|json>');
+      process.exit(0);
+    }
+  }
+
+  if (!inputFile) {
+    console.error('Error: --input <file> is required');
+    process.exit(1);
+  }
+
+  const content = readFileSync(resolve(inputFile), 'utf-8');
+  const isJSON = inputFile.endsWith('.json');
+  const records = isJSON ? parseJSONInput(content) : parseCSVInput(content);
+
+  console.error(`[decoder] Loading question index...`);
+  const indexToQuestion = await loadQuestionIndex();
+  console.error(`[decoder] Loaded ${indexToQuestion.size} questions`);
+  console.error(`[decoder] Decoding ${records.length} tokens...`);
+
+  const decoded = [];
+
+  for (const record of records) {
+    const result = decodeTokenRaw(record.token);
+    if (!result) {
+      console.error(`[decoder] Failed to decode token from session ${record.session_id}`);
+      continue;
+    }
+
+    for (const entry of result.entries) {
+      const q = indexToQuestion.get(entry.index);
+      decoded.push({
+        session_id: record.session_id,
+        timestamp: record.timestamp,
+        domain: record.domain,
+        question_index: entry.index,
+        question_id: q?.id || `unknown_${entry.index}`,
+        question_text: q?.question_text || '',
+        correct_answer: q ? q.options?.[q.correct_answer] || '' : '',
+        is_correct: entry.is_correct,
+        is_skipped: entry.is_skipped,
+      });
+    }
+  }
+
+  // Output
+  if (outputFormat === 'json') {
+    console.log(JSON.stringify(decoded, null, 2));
+  } else {
+    // CSV
+    console.log('session_id,timestamp,domain,question_index,question_id,question_text,correct_answer,is_correct,is_skipped');
+    for (const row of decoded) {
+      const text = `"${(row.question_text || '').replace(/"/g, '""')}"`;
+      const answer = `"${(row.correct_answer || '').replace(/"/g, '""')}"`;
+      console.log(`${row.session_id},${row.timestamp},${row.domain},${row.question_index},${row.question_id},${text},${answer},${row.is_correct},${row.is_skipped}`);
+    }
+  }
+
+  console.error(`[decoder] Decoded ${decoded.length} responses from ${records.length} tokens`);
+}
+
+main().catch(err => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/specs/010-analytics-data-collection/checklists/requirements.md
+++ b/specs/010-analytics-data-collection/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Analytics & Response Data Collection
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-20
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is ready for planning.

--- a/specs/010-analytics-data-collection/contracts/gas-endpoint.md
+++ b/specs/010-analytics-data-collection/contracts/gas-endpoint.md
@@ -1,0 +1,43 @@
+# Contract: Google Apps Script Collection Endpoint
+
+## Request
+
+**Method**: POST
+**URL**: `https://script.google.com/macros/s/{DEPLOYMENT_ID}/exec`
+**Mode**: `no-cors` (fire-and-forget — no response body expected)
+**Content-Type**: `application/json`
+
+### Body
+
+```json
+{
+  "session_id": "a1b2c3d4",
+  "token": "O8LAwTDnP-NPJiap_8xO_...",
+  "response_count": 10,
+  "domain": "all"
+}
+```
+
+| Field | Type | Required | Description |
+|-|-|-|-|
+| session_id | string | yes | 8-char hex, generated per page load |
+| token | string | yes | Base64url-encoded response token from `encodeToken()` |
+| response_count | integer | yes | Total responses in the token |
+| domain | string | yes | Active domain ID at time of send |
+
+## Response
+
+Not inspected (no-cors mode). The client treats all sends as fire-and-forget.
+
+## Google Apps Script Handler
+
+The `doPost(e)` function:
+1. Parses `e.postData.contents` as JSON
+2. Appends a row to the configured sheet: `[new Date(), session_id, token, response_count, domain]`
+3. Returns `ContentService.createTextOutput('ok')`
+
+## Error Handling
+
+- Network failure: silently caught, logged to console
+- Invalid JSON: GAS returns error, client ignores (no-cors)
+- Quota exceeded: GAS returns 429, client ignores (no-cors)

--- a/specs/010-analytics-data-collection/data-model.md
+++ b/specs/010-analytics-data-collection/data-model.md
@@ -1,0 +1,58 @@
+# Data Model: Analytics & Response Data Collection
+
+## Entities
+
+### Collection Record (Google Sheet row)
+
+| Field | Description |
+|-|-|
+| timestamp | ISO 8601 datetime when the token was received by the Apps Script |
+| session_id | Random 8-char hex string, generated once per browser session (not persisted across sessions) |
+| token | Base64url-encoded deflate-compressed binary response token (from existing codec) |
+| response_count | Number of responses encoded in the token |
+| domain | Active domain ID at time of collection (e.g., "all", "psychology") |
+
+**Identity**: No unique constraint — multiple rows per session are expected (one every N responses).
+
+**Lifecycle**: Append-only. Rows are never updated or deleted by the system.
+
+### Collection Preference (localStorage)
+
+| Key | Type | Default | Description |
+|-|-|-|-|
+| `mapper:collectResponses` | boolean | `true` | Whether the user consents to response collection |
+
+**Lifecycle**: Set on first tutorial completion (or remains default if tutorial skipped). Toggled via About modal. Persists across sessions.
+
+### Session ID (in-memory)
+
+Generated once per page load via `crypto.randomUUID().slice(0,8)` or equivalent. Not persisted to localStorage — a new session ID is created on each visit. Used only to group collection records from the same browsing session in the Google Sheet.
+
+## Relationships
+
+```
+User Session (browser tab)
+  └── generates 0..N Collection Records (every N responses)
+       └── each contains 1 Response Token (cumulative snapshot)
+
+Collection Preference
+  └── gates whether Collection Records are sent
+```
+
+## Data Flow
+
+```
+User answers question
+  → $responses store updated (existing flow)
+  → if (responseCount % N === 0) AND (collectResponses === true) AND (not shared view):
+      → encodeToken($responses.get(), questionIndex) → token string
+      → POST { session_id, token, response_count, domain } to GAS endpoint
+      → GAS appends row to Google Sheet with server timestamp
+```
+
+## Volume Estimates
+
+- ~100 responses per engaged session → ~10 collection records per session (at N=10)
+- Token size: ~340 chars for 100 responses
+- POST payload: ~500 bytes per request
+- At 1000 daily users: ~10,000 requests/day (within GAS free quota of 20,000)

--- a/specs/010-analytics-data-collection/plan.md
+++ b/specs/010-analytics-data-collection/plan.md
@@ -1,0 +1,72 @@
+# Implementation Plan: Analytics & Response Data Collection
+
+**Branch**: `010-analytics-data-collection` | **Date**: 2026-03-21 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/010-analytics-data-collection/spec.md`
+
+## Summary
+
+Add visitor analytics (GoatCounter snippet) and anonymized response data collection (token encoding → Google Apps Script → Google Sheet) to the Knowledge Mapper. Includes a tutorial consent step ("Contribute to science!"), an About modal opt-out toggle, and an offline token decoder script. All changes are feature-flagged and must not affect the live site until explicitly signed off.
+
+## Technical Context
+
+**Language/Version**: JavaScript ES2022+ (ES modules), HTML5, CSS3
+**Primary Dependencies**: nanostores 1.1, Vite 7.3, pako (existing — for token deflate), GoatCounter (external CDN script)
+**Storage**: localStorage (opt-out preference), Google Sheets (collection records via GAS)
+**Testing**: Vitest (unit), Playwright (E2E)
+**Target Platform**: Static web app on GitHub Pages, all modern browsers
+**Project Type**: Web application (client-side SPA)
+**Performance Goals**: Collection must add no perceptible delay to quiz flow
+**Constraints**: No changes to main without sign-off; no PII in collected data; no cookies
+**Scale/Scope**: ~1000 daily users initially, ~10K requests/day to GAS endpoint
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **Principle I (Accuracy)**: ✅ No new data content or questions. Token codec reuse preserves encoding fidelity. Decoder script enables round-trip verification.
+- **Principle II (User Delight)**: ✅ No visible UI changes except opt-out toggle in About modal and consent step in tutorial. Collection is silent and non-blocking. Must verify tutorial step visually via Playwright.
+- **Principle III (Compatibility)**: ✅ GoatCounter script is async and lightweight. `fetch()` with `no-cors` is universally supported. localStorage is already used throughout. Must test on mobile viewports.
+
+No violations. No complexity tracking needed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/010-analytics-data-collection/
+├── plan.md              # This file
+├── research.md          # Phase 0: technology decisions
+├── data-model.md        # Phase 1: entities and data flow
+├── quickstart.md        # Phase 1: setup guide
+├── contracts/
+│   └── gas-endpoint.md  # Phase 1: GAS endpoint contract
+└── tasks.md             # Phase 2 output (via /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── collection/
+│   └── collector.js     # NEW: response collection module (config, send logic, interval tracking)
+├── ui/
+│   ├── tutorial.js      # MODIFIED: add consent step (ID 15) before completion step
+│   └── about.js         # NEW or MODIFIED: opt-out toggle + disclosure text in About modal
+├── app.js               # MODIFIED: wire collector to handleAnswer, pass questionIndex
+└── sharing/
+    └── token-codec.js   # UNCHANGED: reused by collector
+
+scripts/
+└── decode-tokens.js     # NEW: offline decoder for Google Sheet tokens → CSV/JSON
+
+index.html               # MODIFIED: GoatCounter snippet, About modal disclosure section
+
+tests/
+├── unit/
+│   └── collector.test.js  # NEW: unit tests for collection logic
+└── visual/
+    └── collection-flow.spec.js  # NEW: E2E test for tutorial consent + About toggle
+```
+
+**Structure Decision**: New `src/collection/` directory for the collector module, keeping it isolated from existing code. The collector imports from `src/sharing/token-codec.js` (existing). Tutorial and About modal changes are minimal modifications to existing files.

--- a/specs/010-analytics-data-collection/quickstart.md
+++ b/specs/010-analytics-data-collection/quickstart.md
@@ -1,0 +1,71 @@
+# Quickstart: Analytics & Response Data Collection
+
+## Prerequisites
+
+- Node.js 18+ and npm
+- A Google account (for Google Apps Script + Sheets)
+- GoatCounter account already set up at context-lab.goatcounter.com
+
+## Step 1: Add GoatCounter Analytics Snippet
+
+Add the following to `index.html` before `</body>`:
+
+```html
+<script data-goatcounter="https://context-lab.goatcounter.com/count"
+        async src="//gc.zgo.at/count.js"></script>
+```
+
+Verify at https://context-lab.goatcounter.com/ after a page visit.
+
+## Step 2: Create Google Apps Script Endpoint
+
+1. Go to https://script.google.com/ → New project
+2. Replace `Code.gs` with:
+
+```javascript
+function doPost(e) {
+  var sheet = SpreadsheetApp.openById('SHEET_ID').getActiveSheet();
+  var data = JSON.parse(e.postData.contents);
+  sheet.appendRow([
+    new Date(),
+    data.session_id,
+    data.token,
+    data.response_count,
+    data.domain
+  ]);
+  return ContentService.createTextOutput('ok');
+}
+```
+
+3. Deploy → New deployment → Web app → Execute as: Me, Who has access: Anyone
+4. Copy the deployment URL
+
+## Step 3: Configure Collection in Mapper
+
+Set the endpoint URL in the collection module config (e.g., `src/collection/collector.js`):
+
+```javascript
+const CONFIG = {
+  ENABLED: true,
+  ENDPOINT_URL: 'https://script.google.com/macros/s/DEPLOYMENT_ID/exec',
+  INTERVAL: 10,  // send every N responses
+};
+```
+
+## Step 4: Test Locally
+
+1. `npm run dev` — start local dev server
+2. Answer 10 questions
+3. Check browser console for `[collector] Sent token` log
+4. Check Google Sheet for new row
+
+## Step 5: Run Tests
+
+```bash
+npm test        # unit tests
+npm run lint    # linting
+```
+
+## Step 6: Get Sign-Off
+
+**CRITICAL**: Do NOT push to main or merge without explicit project owner approval. The live site is under active reporter review.

--- a/specs/010-analytics-data-collection/research.md
+++ b/specs/010-analytics-data-collection/research.md
@@ -1,0 +1,70 @@
+# Research: Analytics & Response Data Collection
+
+## Decision 1: Analytics Service
+
+**Decision**: GoatCounter (free tier, context-lab.goatcounter.com)
+**Rationale**: Cookie-free, privacy-respecting, no consent banner needed. Free tier covers the project's scale. User already created account and provided the snippet.
+**Alternatives considered**:
+- Cloudflare Web Analytics — requires Cloudflare proxy (site is direct GitHub Pages)
+- Plausible — self-hosted is free but requires server; cloud is paid
+- Umami — self-hosted only, requires server
+- Google Analytics — uses cookies, requires consent banner, privacy concerns
+
+## Decision 2: Response Collection Transport
+
+**Decision**: Google Apps Script web app endpoint, called via `fetch()` with `no-cors` mode or `navigator.sendBeacon()`
+**Rationale**: Free, no server to maintain, data lands directly in Google Sheets for easy research access. The existing token codec produces compact payloads (~300-400 chars for 100 responses) well within URL/body limits.
+**Alternatives considered**:
+- Custom backend server — operational burden, cost
+- Google Forms — limited programmatic submission, no custom fields
+- Firebase — overkill for append-only logging
+- Direct Sheets API — requires OAuth, complex auth flow from browser
+
+**Implementation notes**:
+- Google Apps Script web apps deployed as "Execute as me, Anyone can access" provide a public POST endpoint
+- The script receives JSON via `doPost(e)`, parses `e.postData.contents`, and appends to a sheet
+- Free quota: ~20,000 requests/day — sufficient for early-stage collection
+- CORS: GAS web apps redirect on POST, so use `mode: 'no-cors'` (fire-and-forget, no response body needed)
+
+## Decision 3: Token Reuse Strategy
+
+**Decision**: Reuse `encodeToken()` from `src/sharing/token-codec.js` directly
+**Rationale**: The function already encodes responses into a compact binary format (question index + correctness). The `questionIndex` is built from `allDomainBundle.questions` at boot and available via `window.__mapper`. No new encoding logic needed.
+**Key details**:
+- `encodeToken(responses, questionIndex)` → base64url string
+- Input: `$responses.get()` (the reactive store) + `questionIndex` (built at boot)
+- Output: ~340 chars for 100 responses (deflate-compressed)
+- The `questionIndex.version` field (question count mod 256) enables decoder to detect schema mismatches
+
+## Decision 4: Feature Flag Mechanism
+
+**Decision**: Config object at top of collection module with `ENABLED` boolean and `ENDPOINT_URL` string
+**Rationale**: Simple, no build-time env vars needed (Vite doesn't use them currently). Can be toggled by editing one file. If endpoint URL is empty/null, collection is disabled regardless of flag.
+**Alternatives considered**:
+- Vite env vars (`.env` file) — adds build complexity, secrets in repo
+- URL query param — too easy to accidentally enable/disable
+- localStorage flag — admin-only, but could be confused with user opt-out
+
+## Decision 5: Opt-Out Persistence
+
+**Decision**: `localStorage` key `mapper:collectResponses` (boolean, default `true`)
+**Rationale**: Consistent with existing persistence pattern (`mapper:responses`, `mapper:schema`, `mapper:watchedVideos`). Simple to check before sending.
+
+## Decision 6: Tutorial Integration
+
+**Decision**: Add new tutorial step (ID 15) before current completion step (which becomes ID 16)
+**Rationale**: The tutorial STEPS array is ordered by ID. The current final step (ID 15, `isCompletion: true`) becomes ID 16. The new step shows a "Contribute to science!" modal with "I'd like to help!" / "No thanks" buttons. The `advanceOn` trigger fires on either button click, setting the collection preference before advancing.
+**Key details**:
+- New step inserted at STEPS array position before the completion step
+- `isCompletion` stays on the final step (now ID 16)
+- The consent step uses `advanceOn: 'consent-choice'` — a new custom event
+- Button click handlers set `localStorage.setItem('mapper:collectResponses', ...)` and fire the advance event
+
+## Decision 7: About Modal Disclosure
+
+**Decision**: Add a "Data Collection" section at the bottom of the About modal with disclosure text and a toggle switch
+**Rationale**: Matches the existing modal structure (h3 sections). The toggle uses the same visual style as the auto-advance toggle in the quiz panel for consistency.
+**Key details**:
+- HTML added before `</div>` of `.modal-content` in index.html
+- Toggle reads/writes `mapper:collectResponses` in localStorage
+- Text: "We collect anonymized quiz responses (answers only) to help improve our system. No personal information is stored."

--- a/specs/010-analytics-data-collection/spec.md
+++ b/specs/010-analytics-data-collection/spec.md
@@ -1,0 +1,169 @@
+# Feature Specification: Analytics & Response Data Collection
+
+**Feature Branch**: `010-analytics-data-collection`
+**Created**: 2026-03-20
+**Status**: Draft
+**Input**: User description: "Explore visitor analytics tracking and response data collection via Google Apps Scripts. CRITICAL: demo is LIVE and under reporter review — no changes to main until tested and signed off."
+
+## Deployment Safety *(mandatory constraint)*
+
+The live demo at context-lab.com/mapper/ is actively being reviewed by reporters. All changes:
+
+1. MUST be developed and tested on a feature branch — never pushed directly to main
+2. MUST be verified locally with full regression testing before any merge
+3. MUST receive explicit sign-off from the project owner before merging or deploying
+4. MUST NOT alter existing functionality, performance, or user experience
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Visitor Analytics Dashboard (Priority: P1)
+
+A researcher wants to understand how many people are visiting the Knowledge Mapper demo, where they're coming from, and what devices/browsers they use — without paying for analytics services and without adding tracking code that could affect site performance or user privacy.
+
+**Why this priority**: Understanding visitor volume and demographics is the most immediately useful data for gauging interest from reporters and the public. It requires zero code changes to the live site.
+
+**Independent Test**: Can be fully verified by checking that analytics data appears in the dashboard after visiting the live site, with no code deployed to the mapper itself.
+
+**Acceptance Scenarios**:
+
+1. **Given** the analytics service is configured, **When** a user visits the Knowledge Mapper, **Then** the visit is recorded with timestamp, approximate location, browser, device type, and referrer
+2. **Given** multiple visits from the same browser, **When** viewing analytics, **Then** unique vs. repeat visitors are distinguishable
+3. **Given** a reporter shares the link on social media, **When** visitors arrive via that link, **Then** the referrer source is captured
+
+---
+
+### User Story 2 — Automatic Response Collection (Priority: P1)
+
+A researcher wants to collect anonymized response data from users who answer quiz questions, so they can study knowledge patterns across the population. After every N responses (configurable), the system encodes the current responses as a shareable token and sends it to a Google Sheet via Google Apps Script, without interrupting the user's experience.
+
+**Why this priority**: This is the core research data collection mechanism. The existing token encoding system already compresses responses efficiently — reusing it minimizes new code and keeps payloads small.
+
+**Independent Test**: Can be tested locally by answering questions and verifying that tokens appear in a test Google Sheet at the configured interval.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user has answered N questions (where N is the configured interval), **When** the Nth answer is submitted, **Then** the system silently encodes a token from current responses and sends it to the collection endpoint
+2. **Given** the user continues answering, **When** they reach 2N responses, **Then** a second token is sent (capturing cumulative progress)
+3. **Given** the collection endpoint is unreachable, **When** a send fails, **Then** the failure is silently logged to the console and the user's experience is unaffected
+4. **Given** a user in shared view mode (viewing someone else's token), **When** they browse the shared map, **Then** no response data is collected from them
+
+---
+
+### User Story 3 — Tutorial Consent Step (Priority: P2)
+
+When a user completes the tutorial, they see a final "Contribute to science!" modal that transparently explains data collection and lets them choose to opt in or out before the tutorial closes.
+
+**Why this priority**: Proactive transparency builds trust — especially important given reporter scrutiny. Presenting the choice during onboarding ensures informed consent without being disruptive.
+
+**Independent Test**: Can be tested by running through the tutorial and verifying the consent modal appears as the final step, and that the user's choice correctly sets the collection toggle.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user is taking the tutorial, **When** they reach the final step, **Then** a "Contribute to science!" modal appears with explanatory text and two buttons
+2. **Given** the consent modal is displayed, **When** the user clicks "I'd like to help!", **Then** data collection is enabled and the tutorial closes
+3. **Given** the consent modal is displayed, **When** the user clicks "No thanks", **Then** data collection is disabled and the tutorial closes
+4. **Given** the user skipped the tutorial, **When** they use the app, **Then** collection defaults to ON (the About modal toggle serves as the fallback opt-out)
+
+---
+
+### User Story 4 — Opt-Out Toggle in About Modal (Priority: P2)
+
+A user who wants to change their data collection preference at any time can do so via a toggle in the About modal. The system respects this preference across sessions.
+
+**Why this priority**: Provides ongoing control after the tutorial, and serves as the sole opt-out mechanism for users who skipped the tutorial.
+
+**Independent Test**: Can be tested by toggling the setting in the About modal and verifying no data is sent on subsequent responses.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user opens the About modal, **When** they see the data collection section, **Then** a toggle switch and disclosure text are visible
+2. **Given** a user disables collection via the toggle, **When** they answer questions, **Then** no tokens are sent to the collection endpoint
+3. **Given** a user has opted out, **When** they return in a new session, **Then** the opt-out preference is remembered
+4. **Given** a user re-enables collection, **When** they answer the next batch of N questions, **Then** collection resumes normally
+
+---
+
+### User Story 5 — Response Data Decoding (Priority: P3)
+
+A researcher wants to decode the collected tokens in the Google Sheet back into structured response data for analysis.
+
+**Why this priority**: Without decoding, the tokens are opaque. But collection must work first, and decoding can be done offline with a separate script.
+
+**Independent Test**: Can be tested by taking a token from the Google Sheet and running the decoder to verify it produces the expected question-by-question results.
+
+**Acceptance Scenarios**:
+
+1. **Given** a token in the Google Sheet, **When** the researcher runs the decoder, **Then** each response is expanded to show question text, selected answer, correct answer, and correctness
+2. **Given** a batch of tokens, **When** decoded, **Then** the output can be exported as CSV for further analysis
+
+---
+
+### Edge Cases
+
+- What happens when the user answers fewer than N questions and leaves the site? Partial sessions below the threshold are not collected (acceptable data loss for simplicity).
+- What happens if the Google Apps Script quota is exceeded? Sends fail silently; the user experience is unaffected. Data is lost for that interval.
+- What happens if two tabs are open simultaneously? Each tab tracks its own response count independently.
+- What happens on the very first visit before any analytics service is configured? Nothing — analytics is a separate, external service with no code in the mapper.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Analytics (external — no mapper code changes)**:
+
+- **FR-001**: The project MUST use a free, privacy-respecting analytics service that requires no code changes to the mapper site (e.g., Cloudflare Web Analytics via CDN proxy, or a lightweight script tag)
+- **FR-002**: Analytics MUST track: page views, unique visitors, referrer sources, browser/device type, and approximate geographic location
+- **FR-003**: Analytics MUST NOT use cookies or invasive client-side tracking that would require a consent banner. GoatCounter (free tier) has been selected; the snippet will be added to index.html. Dashboard: https://context-lab.goatcounter.com/
+
+**Response Collection (requires mapper code changes — feature-flagged)**:
+
+- **FR-004**: System MUST encode current responses as a token (reusing the existing token codec) after every N responses, where N is configurable
+- **FR-005**: System MUST send the encoded token to a Google Apps Script web app endpoint via a background request
+- **FR-006**: The Google Apps Script MUST append each received token as a new row in a Google Sheet, along with a timestamp and a session identifier (random, non-identifying)
+- **FR-007**: System MUST fail silently on network errors — no user-visible errors, no retries, no impact on quiz flow
+- **FR-008**: System MUST NOT collect data when in shared view mode (URL has `?t=` parameter)
+- **FR-009**: System MUST collect responses by default and provide a user-facing opt-out toggle that persists across sessions
+- **FR-010**: System MUST NOT send any personally identifiable information — tokens contain only question indices and answer correctness
+- **FR-011**: All response collection code MUST be feature-flagged so it can be disabled without a code change
+- **FR-014**: The About modal MUST disclose that anonymized responses (answers only) are collected to help improve the system, and MUST include an opt-out toggle switch (collection is on by default)
+- **FR-015**: The tutorial (if the user elects to take it) MUST include a final step before closing — a modal titled "Contribute to science!" with the text: "This demo is just the beginning! We are working towards new tools for democratizing education and helping *all* people achieve their learning goals and dreams. Would you consider sharing your (anonymized) quiz responses with us to help us improve our system? You can change your mind at any time by clicking the [info icon] about button and toggling the switch." The info icon MUST match the existing About button icon and be vertically aligned with the surrounding text. Two buttons MUST be presented: "I'd like to help!" (enables collection) and "No thanks" (disables collection). The user's choice MUST update the opt-out toggle state accordingly
+
+**Decoding (offline tooling)**:
+
+- **FR-012**: A standalone script MUST be provided to decode tokens from the Google Sheet into structured response data
+- **FR-013**: The decoder MUST output results in a format suitable for data analysis (CSV or JSON)
+
+### Key Entities
+
+- **Visit**: A page view event captured by the analytics service — timestamp, IP-derived location, browser, device, referrer
+- **Response Token**: A compressed binary encoding of a user's quiz responses (question index + answer correctness), base64url-encoded — already defined by the existing token codec
+- **Collection Record**: A row in the Google Sheet — timestamp, session ID, response token, domain name
+- **Session ID**: A random identifier generated per browser session (not tied to any user identity), used only to group tokens from the same session
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Within 24 hours of enabling analytics, the research team can see visitor counts, referrer sources, and geographic distribution
+- **SC-002**: Response tokens are collected for at least 80% of sessions where users answer N or more questions (accounting for network failures and opt-outs)
+- **SC-003**: Collected tokens can be decoded back into structured response data with 100% fidelity (no data loss in encoding/decoding round-trip)
+- **SC-004**: The response collection mechanism adds no perceptible delay to the quiz answering flow
+- **SC-005**: Zero regressions in existing functionality — all current tests continue to pass
+- **SC-006**: No user-visible changes to the app unless the user opens the About modal (where the opt-out toggle and data collection disclosure live)
+- **SC-007**: The live site is never affected by development work until explicit sign-off is given
+
+## Clarifications
+
+### Session 2026-03-21
+
+- Q: Should data collection be on by default (opt-out) or off by default (opt-in)? → A: Opt-out — collection is ON by default, users can disable it
+- Q: Where should the opt-out toggle be placed in the UI? → A: Inside the existing About modal, with disclosure text explaining that anonymized responses (answers only) are collected to help improve the system. Additionally, the tutorial adds a final "Contribute to science!" step that transparently asks users to opt in/out before closing
+- Q: Which analytics service? → A: GoatCounter free tier (context-lab.goatcounter.com), snippet provided by user
+
+## Assumptions
+
+- The site is served directly from GitHub Pages (not via Cloudflare). GoatCounter (context-lab.goatcounter.com) has been set up for cookie-free analytics.
+- Google Apps Script web apps have a quota of ~20,000 requests/day on the free tier, which is sufficient for early-stage data collection.
+- The existing `encodeToken()` function from the token codec can be reused directly for response collection.
+- N (the collection interval) defaults to 10 responses but is configurable.
+- The opt-out preference is stored in localStorage alongside other user preferences.

--- a/specs/010-analytics-data-collection/tasks.md
+++ b/specs/010-analytics-data-collection/tasks.md
@@ -1,0 +1,201 @@
+# Tasks: Analytics & Response Data Collection
+
+**Input**: Design documents from `/specs/010-analytics-data-collection/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Create collection module structure and shared infrastructure
+
+- [X] T001 Create `src/collection/` directory and `src/collection/collector.js` module scaffold with CONFIG object (ENABLED, ENDPOINT_URL, INTERVAL) and exports
+- [X] T002 [P] Add `mapper:collectResponses` localStorage key handling — helper functions `isCollectionEnabled()` and `setCollectionEnabled(value)` in `src/collection/collector.js`
+- [X] T003 [P] Generate session ID (8-char hex via `crypto.randomUUID().slice(0,8)`) in `src/collection/collector.js` — created once per page load, not persisted
+
+**Checkpoint**: Collection module exists with config, preference helpers, and session ID generation
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Google Apps Script endpoint must exist before any collection can be tested
+
+**⚠️ CRITICAL**: US2 (response collection) cannot be tested without a working GAS endpoint
+
+- [X] T004 Create Google Apps Script project with `doPost(e)` handler per `specs/010-analytics-data-collection/contracts/gas-endpoint.md` — deploy as web app (Execute as: Me, Anyone can access)
+- [X] T005 Create target Google Sheet with columns: Timestamp, Session ID, Token, Response Count, Domain
+- [X] T006 Test GAS endpoint manually with a `curl` POST to verify rows appear in the sheet
+
+**Checkpoint**: GAS endpoint is live and accepting POST requests — verified with manual test
+
+---
+
+## Phase 3: User Story 1 — Visitor Analytics (Priority: P1) 🎯 MVP
+
+**Goal**: Add GoatCounter analytics snippet so researcher can see visitor traffic
+
+**Independent Test**: Visit the local dev server, then check context-lab.goatcounter.com for the visit (only works after deploy — local test verifies snippet is present in HTML)
+
+- [X] T007 [US1] Add GoatCounter snippet to `index.html` before `</body>`: `<script data-goatcounter="https://context-lab.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>`
+- [X] T008 [US1] Verify snippet loads without errors on local dev server (check browser console and network tab)
+
+**Checkpoint**: GoatCounter snippet is in index.html and loads cleanly. Analytics will be live after deploy.
+
+---
+
+## Phase 4: User Story 2 — Automatic Response Collection (Priority: P1)
+
+**Goal**: After every N responses, silently encode a token and POST it to the GAS endpoint
+
+**Independent Test**: Answer 10 questions locally, verify a row appears in the test Google Sheet with correct token
+
+### Implementation for User Story 2
+
+- [X] T009 [US2] Implement `sendToken(token, responseCount, domain, sessionId)` in `src/collection/collector.js` — `fetch()` POST to ENDPOINT_URL with `mode: 'no-cors'`, catch errors silently with `console.warn('[collector]', err)`
+- [X] T010 [US2] Implement `maybeCollect(responses, questionIndex, activeDomain)` in `src/collection/collector.js` — checks: ENABLED, not shared view (`?t=` absent), collection preference enabled, `responses.length % INTERVAL === 0 && responses.length > 0`. If all pass, calls `encodeToken()` and `sendToken()`
+- [X] T011 [US2] Wire `maybeCollect()` into `src/app.js` — call from `handleAnswer()` after response is added to `$responses`, passing `$responses.get()`, `questionIndex`, and `$activeDomain.get()`
+- [X] T012 [US2] Add shared-view guard in `maybeCollect()` — check `new URLSearchParams(window.location.search).has('t')` and skip if true
+- [X] T013 [US2] Test end-to-end: start local dev server, answer 10 questions (N=10), verify row in Google Sheet with valid token, session_id, response_count=10, and domain
+
+**Checkpoint**: Answering 10 questions causes a token row to appear in the Google Sheet. Shared view does not trigger collection.
+
+---
+
+## Phase 5: User Story 3 — Tutorial Consent Step (Priority: P2)
+
+**Goal**: Add a final tutorial step "Contribute to science!" that lets users opt in or out of data collection
+
+**Independent Test**: Run through the tutorial, verify the consent modal appears as the last step before "Tutorial Complete!", and that button clicks correctly set the localStorage preference
+
+### Implementation for User Story 3
+
+- [X] T014 [US3] Add new tutorial step object in `src/ui/tutorial.js` STEPS array — insert before the current completion step (ID 15 becomes consent, current 15 becomes 16). Set `title: 'Contribute to science!'`, custom message with info icon inline, `advanceOn: 'consent-choice'`
+- [X] T015 [US3] Update the completion step ID from 15 to 16 and ensure `isCompletion: true` stays on the final step in `src/ui/tutorial.js`
+- [X] T016 [US3] Implement consent step rendering in `src/ui/tutorial.js` — when step 15 is active, render two buttons: "I'd like to help!" and "No thanks". Button clicks call `setCollectionEnabled(true/false)` from collector.js and fire the `consent-choice` advance event
+- [X] T017 [US3] Style the consent buttons in `src/ui/tutorial.css` — "I'd like to help!" uses primary green (matching landing-start-btn style), "No thanks" uses outline/secondary style
+- [X] T018 [US3] Render the inline info icon (`<i class="fa-solid fa-circle-info">`) in the consent message text, vertically aligned with surrounding text via `vertical-align: middle`
+- [X] T019 [US3] Visually verify consent step via Playwright screenshot at desktop (1280×800) and landscape mobile (812×375) viewports
+
+**Checkpoint**: Tutorial shows consent modal before completion. "I'd like to help!" enables collection, "No thanks" disables it. Preference persists in localStorage.
+
+---
+
+## Phase 6: User Story 4 — About Modal Opt-Out Toggle (Priority: P2)
+
+**Goal**: Add disclosure text and opt-out toggle switch to the About modal
+
+**Independent Test**: Open About modal, verify disclosure text and toggle are visible. Toggle off, answer questions, verify no collection. Toggle on, answer N more, verify collection resumes.
+
+### Implementation for User Story 4
+
+- [X] T020 [US4] Add "Data Collection" section to About modal in `index.html` — new `<h3>Data Collection</h3>` section before closing `</div>` of `.modal-content`, with disclosure text: "We collect anonymized quiz responses (answers only) to help improve our system. No personal information is stored."
+- [X] T021 [US4] Add toggle switch HTML in the About modal data collection section in `index.html` — reuse the same visual pattern as the auto-advance toggle (track + thumb divs with role="switch")
+- [X] T022 [US4] Wire toggle switch behavior in `src/app.js` `setupAboutModal()` — read initial state from `isCollectionEnabled()`, toggle calls `setCollectionEnabled()`, update visual state on click
+- [X] T023 [US4] Sync toggle state on modal open — when About modal opens, read current `isCollectionEnabled()` and set toggle position (in case it was changed by tutorial consent step)
+- [X] T024 [US4] Visually verify About modal toggle via Playwright screenshot
+
+**Checkpoint**: About modal shows disclosure and working toggle. Toggle state syncs with localStorage and affects collection behavior.
+
+---
+
+## Phase 7: User Story 5 — Response Data Decoding (Priority: P3)
+
+**Goal**: Provide an offline script to decode tokens from the Google Sheet into structured data for analysis
+
+**Independent Test**: Export a CSV from the Google Sheet, run the decoder script, verify output contains correct question text and answer data for each token
+
+### Implementation for User Story 5
+
+- [X] T025 [US5] Create `scripts/decode-tokens.js` — Node.js script that reads a CSV/JSON file of tokens, imports `decodeToken` and `buildIndex` from the codec/index modules, and decodes each token
+- [X] T026 [US5] Implement output formatting in `scripts/decode-tokens.js` — for each decoded response, output: question_id, question_text (looked up from domain bundles), is_correct, is_skipped. Support `--format csv` and `--format json` flags
+- [X] T027 [US5] Add usage documentation as a comment block at the top of `scripts/decode-tokens.js` — example: `node scripts/decode-tokens.js --input tokens.csv --format csv > decoded.csv`
+- [X] T028 [US5] Test decoder with the known token `O8LAwTDnP-NPJiap_8xO_1kW_2flZmI1ZmIP-w8A` — verify it produces the expected 100 responses with correct/incorrect flags
+
+**Checkpoint**: Decoder script converts tokens to structured data. Round-trip fidelity is 100%.
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: Regression testing, feature flag verification, final sign-off preparation
+
+- [X] T029 Run full test suite (`npm test && npm run lint`) and verify zero regressions
+- [X] T030 [P] Verify feature flag — set `CONFIG.ENABLED = false` in collector.js, answer N questions, confirm no POST requests are made
+- [X] T031 [P] Verify shared view guard — visit a `?t=` URL, answer questions (if possible), confirm no collection
+- [X] T032 Test opt-out flow end-to-end: tutorial consent → "No thanks" → answer 10+ questions → verify no rows in sheet → About modal toggle ON → answer 10 more → verify row appears
+- [X] T033 Run Playwright E2E tests across chromium, firefox, webkit to verify no visual regressions
+- [X] T034 Prepare sign-off summary for project owner: list all changes, affected files, test results, screenshots
+
+**Checkpoint**: All tests pass, feature flags work, opt-out flow verified. Ready for project owner sign-off before merge to main.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: Independent of Phase 1 — GAS setup is external
+- **US1 Analytics (Phase 3)**: Independent — just a snippet addition, can run in parallel with anything
+- **US2 Collection (Phase 4)**: Depends on Phase 1 (collector module) + Phase 2 (GAS endpoint)
+- **US3 Tutorial Consent (Phase 5)**: Depends on Phase 1 (collector preference helpers)
+- **US4 About Toggle (Phase 6)**: Depends on Phase 1 (collector preference helpers)
+- **US5 Decoding (Phase 7)**: Independent — offline script, no runtime dependencies
+- **Polish (Phase 8)**: Depends on all desired user stories being complete
+
+### User Story Dependencies
+
+- **US1 (Analytics)**: Fully independent — no dependencies on other stories
+- **US2 (Collection)**: Depends on Phase 1 + Phase 2 only — independent of US3/US4/US5
+- **US3 (Tutorial Consent)**: Depends on Phase 1 preference helpers — independent of US2/US4/US5
+- **US4 (About Toggle)**: Depends on Phase 1 preference helpers — independent of US2/US3/US5
+- **US5 (Decoding)**: Fully independent — offline script
+
+### Parallel Opportunities
+
+- **Phase 1**: T002 and T003 can run in parallel (different functions, same file but independent)
+- **Phase 2 + Phase 3**: GAS setup (T004-T006) and GoatCounter snippet (T007-T008) can run in parallel
+- **Phase 5 + Phase 6**: Tutorial consent and About toggle can be built in parallel (different files)
+- **Phase 7**: Decoder script can be built any time — no runtime dependencies
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 + US2)
+
+1. Complete Phase 1: Setup (collector module scaffold)
+2. Complete Phase 2: GAS endpoint (external setup)
+3. Complete Phase 3: GoatCounter snippet (trivial)
+4. Complete Phase 4: Response collection wiring
+5. **STOP and VALIDATE**: Verify analytics dashboard + collection rows in sheet
+6. Get sign-off for GoatCounter snippet deployment (low risk, high value)
+
+### Incremental Delivery
+
+1. Setup + GAS endpoint → Foundation ready
+2. Add GoatCounter → Analytics live (after deploy)
+3. Add response collection → Data flowing to sheet
+4. Add tutorial consent + About toggle → Transparency complete
+5. Add decoder script → Research-ready data pipeline
+6. **Sign-off and merge** — only after project owner approval
+
+---
+
+## Notes
+
+- **CRITICAL**: No push to main or merge without explicit project owner sign-off
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Commit after each task or logical group
+- The GoatCounter snippet (US1) is the lowest-risk change and could be deployed first
+- The GAS endpoint setup (Phase 2) is external and doesn't touch the mapper codebase

--- a/src/app.js
+++ b/src/app.js
@@ -39,6 +39,7 @@ import { updateConfidence, initConfidence } from './ui/progress.js';
 import { announce, setupKeyboardNav } from './utils/accessibility.js';
 import { lockLandscape, unlockOrientation } from './ui/orientation.js';
 import { decodeSharedToken, applySharedViewChrome } from './sharing/shared-view.js';
+import { maybeCollect, isCollectionEnabled, setCollectionEnabled } from './collection/collector.js';
 
 const GLOBAL_REGION = { x_min: 0, x_max: 1, y_min: 0, y_max: 1 };
 const GLOBAL_GRID_SIZE = 50;
@@ -823,6 +824,9 @@ function handleAnswer(selectedKey, question) {
     updateInsightButtons($responses.get().length);
   }
 
+  // Anonymized response collection (every N responses, fire-and-forget)
+  maybeCollect($responses.get(), questionIndex, activeDomainId);
+
   // Show answer dot and feedback immediately (before expensive GP computation)
   renderer.setAnsweredQuestions(responsesToAnsweredDots($responses.get(), questionIndex));
 
@@ -909,6 +913,9 @@ function handleSkip() {
     modes.updateAvailability(domainQuestionCount);
     updateInsightButtons($responses.get().length);
   }
+
+  // Anonymized response collection (every N responses, fire-and-forget)
+  maybeCollect($responses.get(), questionIndex, activeDomainId);
 
   // Show answer dot and feedback immediately (before expensive GP computation)
   renderer.setAnsweredQuestions(responsesToAnsweredDots($responses.get(), questionIndex));
@@ -1342,12 +1349,40 @@ function setupAboutModal() {
   const btn = document.getElementById('about-btn');
   const modal = document.getElementById('about-modal');
   if (!btn || !modal) return;
-  btn.addEventListener('click', () => { modal.hidden = !modal.hidden; });
+  // Sync collection toggle state when modal opens
+  function syncCollectToggle() {
+    const track = document.getElementById('collect-toggle-track');
+    const thumb = document.getElementById('collect-toggle-thumb');
+    if (!track || !thumb) return;
+    const enabled = isCollectionEnabled();
+    track.setAttribute('aria-checked', String(enabled));
+    track.style.background = enabled ? 'var(--color-primary, #00693e)' : 'var(--color-text-muted, #94a3b8)';
+    thumb.style.left = enabled ? '18px' : '2px';
+  }
+
+  btn.addEventListener('click', () => {
+    modal.hidden = !modal.hidden;
+    if (!modal.hidden) syncCollectToggle();
+  });
   const closeBtn = modal.querySelector('.close-modal');
   if (closeBtn) closeBtn.addEventListener('click', () => { modal.hidden = true; });
   document.addEventListener('keydown', (e) => {
     if (e.key === 'Escape' && !modal.hidden) modal.hidden = true;
   });
+
+  // Collection toggle click handler
+  const collectTrack = document.getElementById('collect-toggle-track');
+  if (collectTrack) {
+    function toggleCollect() {
+      const newVal = !isCollectionEnabled();
+      setCollectionEnabled(newVal);
+      syncCollectToggle();
+    }
+    collectTrack.addEventListener('click', toggleCollect);
+    collectTrack.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleCollect(); }
+    });
+  }
 
   // Wire up inline info link on landing page to open the about modal
   const landingInfoLink = document.getElementById('landing-info-link');

--- a/src/app.js
+++ b/src/app.js
@@ -1370,6 +1370,9 @@ function setupAboutModal() {
     if (e.key === 'Escape' && !modal.hidden) modal.hidden = true;
   });
 
+  // Sync toggle when preference changes externally (e.g., tutorial consent step)
+  window.addEventListener('collect-pref-change', syncCollectToggle);
+
   // Collection toggle click handler
   const collectTrack = document.getElementById('collect-toggle-track');
   if (collectTrack) {

--- a/src/app.js
+++ b/src/app.js
@@ -825,7 +825,7 @@ function handleAnswer(selectedKey, question) {
   }
 
   // Anonymized response collection (every N responses, fire-and-forget)
-  maybeCollect($responses.get(), aggregatedQuestions.length > 0 ? aggregatedQuestions : allDomainBundle?.questions, activeDomainId);
+  maybeCollect($responses.get(), aggregatedQuestions.length > 0 ? aggregatedQuestions : allDomainBundle?.questions);
 
   // Show answer dot and feedback immediately (before expensive GP computation)
   renderer.setAnsweredQuestions(responsesToAnsweredDots($responses.get(), questionIndex));
@@ -915,7 +915,7 @@ function handleSkip() {
   }
 
   // Anonymized response collection (every N responses, fire-and-forget)
-  maybeCollect($responses.get(), aggregatedQuestions.length > 0 ? aggregatedQuestions : allDomainBundle?.questions, activeDomainId);
+  maybeCollect($responses.get(), aggregatedQuestions.length > 0 ? aggregatedQuestions : allDomainBundle?.questions);
 
   // Show answer dot and feedback immediately (before expensive GP computation)
   renderer.setAnsweredQuestions(responsesToAnsweredDots($responses.get(), questionIndex));

--- a/src/app.js
+++ b/src/app.js
@@ -825,7 +825,7 @@ function handleAnswer(selectedKey, question) {
   }
 
   // Anonymized response collection (every N responses, fire-and-forget)
-  maybeCollect($responses.get(), questionIndex, activeDomainId);
+  maybeCollect($responses.get(), aggregatedQuestions.length > 0 ? aggregatedQuestions : allDomainBundle?.questions, activeDomainId);
 
   // Show answer dot and feedback immediately (before expensive GP computation)
   renderer.setAnsweredQuestions(responsesToAnsweredDots($responses.get(), questionIndex));
@@ -915,7 +915,7 @@ function handleSkip() {
   }
 
   // Anonymized response collection (every N responses, fire-and-forget)
-  maybeCollect($responses.get(), questionIndex, activeDomainId);
+  maybeCollect($responses.get(), aggregatedQuestions.length > 0 ? aggregatedQuestions : allDomainBundle?.questions, activeDomainId);
 
   // Show answer dot and feedback immediately (before expensive GP computation)
   renderer.setAnsweredQuestions(responsesToAnsweredDots($responses.get(), questionIndex));

--- a/src/collection/collector.js
+++ b/src/collection/collector.js
@@ -47,6 +47,10 @@ export function setCollectionEnabled(value) {
   try {
     localStorage.setItem(PREF_KEY, String(!!value));
   } catch { /* noop — localStorage unavailable */ }
+  // Notify any open UI (e.g., About modal toggle) of the change
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent('collect-pref-change'));
+  }
 }
 
 // ── Shared view detection ──────────────────────────────────────────────────

--- a/src/collection/collector.js
+++ b/src/collection/collector.js
@@ -19,7 +19,7 @@ import { buildIndex } from '../sharing/question-index.js';
 // ── Configuration ──────────────────────────────────────────────────────────
 const CONFIG = {
   ENABLED: true,
-  ENDPOINT_URL: 'https://script.google.com/macros/s/AKfycbwYNqjfV0-6FDHxBoLxpq7bK9HJZfD9EydHQoRgFztfn0ijwelEaIvD_uRMhOlMUu0V/exec',
+  ENDPOINT_URL: 'https://script.google.com/macros/s/AKfycbw55yM6nkllMydqg5LJmofcxd8kxlB85J4xMDSF35N_HmliVXdu_MgkMJmsHmkLYIKP/exec',
   INTERVAL: 10,     // Send every N responses
 };
 
@@ -74,8 +74,17 @@ function sendToken(token, responseCount, useBeacon = false) {
     response_count: responseCount,
   });
 
-  if (useBeacon && navigator.sendBeacon) {
-    navigator.sendBeacon(CONFIG.ENDPOINT_URL, new Blob([body], { type: 'application/json' }));
+  if (useBeacon) {
+    // Use fetch with keepalive (survives page unload, follows redirects — unlike sendBeacon)
+    try {
+      fetch(CONFIG.ENDPOINT_URL, {
+        method: 'POST',
+        mode: 'no-cors',
+        keepalive: true,
+        headers: { 'Content-Type': 'application/json' },
+        body,
+      }).catch(() => {});
+    } catch { /* noop */ }
     return;
   }
 

--- a/src/collection/collector.js
+++ b/src/collection/collector.js
@@ -5,6 +5,8 @@
  * (reusing the shareable map link codec) and POSTs it to a Google Apps Script
  * endpoint that appends to a Google Sheet.
  *
+ * Also sends a final beacon on page unload to capture partial sessions.
+ *
  * - Fire-and-forget: errors are silently logged, never shown to the user.
  * - Skipped in shared view mode (?t= URL param).
  * - Respects user opt-out preference in localStorage.
@@ -51,23 +53,31 @@ export function setCollectionEnabled(value) {
 const IS_SHARED_VIEW = typeof window !== 'undefined'
   && new URLSearchParams(window.location.search).has('t');
 
+// ── State tracking ─────────────────────────────────────────────────────────
+let _lastSentCount = 0;       // Response count at last successful send
+let _cachedQuestions = null;   // Cached allQuestions reference for beforeunload
+
 // ── Send logic ─────────────────────────────────────────────────────────────
 
 /**
  * POST a token to the GAS endpoint. Fire-and-forget (no-cors).
  * @param {string} token - base64url-encoded response token
  * @param {number} responseCount - total responses in the token
- * @param {string} domain - active domain ID at time of send
+ * @param {boolean} [useBeacon=false] - use sendBeacon for page unload
  */
-function sendToken(token, responseCount, domain) {
+function sendToken(token, responseCount, useBeacon = false) {
   if (!CONFIG.ENDPOINT_URL) return;
 
   const body = JSON.stringify({
     session_id: SESSION_ID,
     token,
     response_count: responseCount,
-    domain: domain || 'all',
   });
+
+  if (useBeacon && navigator.sendBeacon) {
+    navigator.sendBeacon(CONFIG.ENDPOINT_URL, new Blob([body], { type: 'application/json' }));
+    return;
+  }
 
   try {
     fetch(CONFIG.ENDPOINT_URL, {
@@ -84,26 +94,61 @@ function sendToken(token, responseCount, domain) {
 }
 
 /**
+ * Encode and send the current responses.
+ * @param {Array} responses
+ * @param {Array} allQuestions
+ * @param {boolean} [useBeacon=false]
+ * @returns {boolean} true if sent
+ */
+function encodeAndSend(responses, allQuestions, useBeacon = false) {
+  if (!allQuestions || allQuestions.length === 0) return false;
+
+  const tokenIndex = buildIndex(allQuestions);
+  const token = encodeToken(responses, tokenIndex);
+  if (!token) return false;
+
+  sendToken(token, responses.length, useBeacon);
+  _lastSentCount = responses.length;
+  return true;
+}
+
+/**
  * Check whether collection should fire, and if so, encode + send.
  * Called after each response is added to the store.
  *
  * @param {Array} responses - current $responses.get() array
  * @param {Array} allQuestions - full question array (for building token index)
- * @param {string} activeDomain - current $activeDomain value
  */
-export function maybeCollect(responses, allQuestions, activeDomain) {
+export function maybeCollect(responses, allQuestions) {
   if (!CONFIG.ENABLED) return;
   if (!CONFIG.ENDPOINT_URL) return;
   if (IS_SHARED_VIEW) return;
   if (!isCollectionEnabled()) return;
   if (!responses || responses.length === 0) return;
   if (responses.length % CONFIG.INTERVAL !== 0) return;
-  if (!allQuestions || allQuestions.length === 0) return;
+  if (responses.length === _lastSentCount) return; // avoid duplicate sends
 
-  const tokenIndex = buildIndex(allQuestions);
-  const token = encodeToken(responses, tokenIndex);
-  if (!token) return;
+  _cachedQuestions = allQuestions; // cache for beforeunload
 
-  sendToken(token, responses.length, activeDomain);
-  console.debug('[collector] Sent token (%d responses)', responses.length);
+  if (encodeAndSend(responses, allQuestions)) {
+    console.debug('[collector] Sent token (%d responses)', responses.length);
+  }
+}
+
+// ── Page unload: send partial session via beacon ───────────────────────────
+if (typeof window !== 'undefined' && !IS_SHARED_VIEW) {
+  window.addEventListener('beforeunload', () => {
+    if (!CONFIG.ENABLED || !CONFIG.ENDPOINT_URL) return;
+    if (!isCollectionEnabled()) return;
+    if (!_cachedQuestions) return;
+
+    try {
+      const responses = JSON.parse(localStorage.getItem('mapper:responses') || '[]');
+      // Only send if we have new responses since last send
+      if (responses.length > _lastSentCount && responses.length > 0) {
+        encodeAndSend(responses, _cachedQuestions, true);
+        console.debug('[collector] Beacon sent (%d responses)', responses.length);
+      }
+    } catch { /* noop */ }
+  });
 }

--- a/src/collection/collector.js
+++ b/src/collection/collector.js
@@ -1,0 +1,106 @@
+/**
+ * Anonymized response collection module.
+ *
+ * After every INTERVAL responses, encodes the current responses as a token
+ * (reusing the shareable map link codec) and POSTs it to a Google Apps Script
+ * endpoint that appends to a Google Sheet.
+ *
+ * - Fire-and-forget: errors are silently logged, never shown to the user.
+ * - Skipped in shared view mode (?t= URL param).
+ * - Respects user opt-out preference in localStorage.
+ * - Feature-flagged via CONFIG.ENABLED.
+ */
+
+import { encodeToken } from '../sharing/token-codec.js';
+
+// ── Configuration ──────────────────────────────────────────────────────────
+const CONFIG = {
+  ENABLED: true,
+  ENDPOINT_URL: '', // Google Apps Script deployment URL — empty = disabled
+  INTERVAL: 10,     // Send every N responses
+};
+
+// ── Session ID (per page load, not persisted) ──────────────────────────────
+const SESSION_ID = typeof crypto !== 'undefined' && crypto.randomUUID
+  ? crypto.randomUUID().slice(0, 8)
+  : Math.random().toString(16).slice(2, 10);
+
+// ── Preference helpers ─────────────────────────────────────────────────────
+const PREF_KEY = 'mapper:collectResponses';
+
+/** Check if the user has opted in to response collection (default: true). */
+export function isCollectionEnabled() {
+  try {
+    const val = localStorage.getItem(PREF_KEY);
+    if (val === null) return true; // default: on
+    return val === 'true';
+  } catch {
+    return true;
+  }
+}
+
+/** Set the user's collection preference. */
+export function setCollectionEnabled(value) {
+  try {
+    localStorage.setItem(PREF_KEY, String(!!value));
+  } catch { /* noop — localStorage unavailable */ }
+}
+
+// ── Shared view detection ──────────────────────────────────────────────────
+const IS_SHARED_VIEW = typeof window !== 'undefined'
+  && new URLSearchParams(window.location.search).has('t');
+
+// ── Send logic ─────────────────────────────────────────────────────────────
+
+/**
+ * POST a token to the GAS endpoint. Fire-and-forget (no-cors).
+ * @param {string} token - base64url-encoded response token
+ * @param {number} responseCount - total responses in the token
+ * @param {string} domain - active domain ID at time of send
+ */
+function sendToken(token, responseCount, domain) {
+  if (!CONFIG.ENDPOINT_URL) return;
+
+  const body = JSON.stringify({
+    session_id: SESSION_ID,
+    token,
+    response_count: responseCount,
+    domain: domain || 'all',
+  });
+
+  try {
+    fetch(CONFIG.ENDPOINT_URL, {
+      method: 'POST',
+      mode: 'no-cors',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+    }).catch(err => {
+      console.warn('[collector] Send failed:', err.message || err);
+    });
+  } catch (err) {
+    console.warn('[collector] Send failed:', err.message || err);
+  }
+}
+
+/**
+ * Check whether collection should fire, and if so, encode + send.
+ * Called after each response is added to the store.
+ *
+ * @param {Array} responses - current $responses.get() array
+ * @param {object} questionIndex - { version, toIndex, toId } from buildIndex()
+ * @param {string} activeDomain - current $activeDomain value
+ */
+export function maybeCollect(responses, questionIndex, activeDomain) {
+  if (!CONFIG.ENABLED) return;
+  if (!CONFIG.ENDPOINT_URL) return;
+  if (IS_SHARED_VIEW) return;
+  if (!isCollectionEnabled()) return;
+  if (!responses || responses.length === 0) return;
+  if (responses.length % CONFIG.INTERVAL !== 0) return;
+
+  const token = encodeToken(responses, questionIndex);
+  if (!token) return;
+
+  sendToken(token, responses.length, activeDomain);
+  console.debug('[collector] Sent token (%d responses)', responses.length);
+}

--- a/src/collection/collector.js
+++ b/src/collection/collector.js
@@ -12,11 +12,12 @@
  */
 
 import { encodeToken } from '../sharing/token-codec.js';
+import { buildIndex } from '../sharing/question-index.js';
 
 // ── Configuration ──────────────────────────────────────────────────────────
 const CONFIG = {
   ENABLED: true,
-  ENDPOINT_URL: '', // Google Apps Script deployment URL — empty = disabled
+  ENDPOINT_URL: 'https://script.google.com/macros/s/AKfycbwYNqjfV0-6FDHxBoLxpq7bK9HJZfD9EydHQoRgFztfn0ijwelEaIvD_uRMhOlMUu0V/exec',
   INTERVAL: 10,     // Send every N responses
 };
 
@@ -87,18 +88,20 @@ function sendToken(token, responseCount, domain) {
  * Called after each response is added to the store.
  *
  * @param {Array} responses - current $responses.get() array
- * @param {object} questionIndex - { version, toIndex, toId } from buildIndex()
+ * @param {Array} allQuestions - full question array (for building token index)
  * @param {string} activeDomain - current $activeDomain value
  */
-export function maybeCollect(responses, questionIndex, activeDomain) {
+export function maybeCollect(responses, allQuestions, activeDomain) {
   if (!CONFIG.ENABLED) return;
   if (!CONFIG.ENDPOINT_URL) return;
   if (IS_SHARED_VIEW) return;
   if (!isCollectionEnabled()) return;
   if (!responses || responses.length === 0) return;
   if (responses.length % CONFIG.INTERVAL !== 0) return;
+  if (!allQuestions || allQuestions.length === 0) return;
 
-  const token = encodeToken(responses, questionIndex);
+  const tokenIndex = buildIndex(allQuestions);
+  const token = encodeToken(responses, tokenIndex);
   if (!token) return;
 
   sendToken(token, responses.length, activeDomain);

--- a/src/collection/collector.js
+++ b/src/collection/collector.js
@@ -31,14 +31,14 @@ const SESSION_ID = typeof crypto !== 'undefined' && crypto.randomUUID
 // ── Preference helpers ─────────────────────────────────────────────────────
 const PREF_KEY = 'mapper:collectResponses';
 
-/** Check if the user has opted in to response collection (default: true). */
+/** Check if the user has opted in to response collection (default: false). */
 export function isCollectionEnabled() {
   try {
     const val = localStorage.getItem(PREF_KEY);
-    if (val === null) return true; // default: on
+    if (val === null) return false; // default: off (opt-in via tutorial or About modal)
     return val === 'true';
   } catch {
-    return true;
+    return false;
   }
 }
 

--- a/src/ui/tutorial.css
+++ b/src/ui/tutorial.css
@@ -114,7 +114,9 @@ body.tutorial-active .drawer-pull {
    On mobile, keep overflow scrollable and scroll the highlight into view instead. */
 @media (min-width: 481px) {
   .quiz-content:has(.tutorial-highlight),
-  .video-panel-list:has(.tutorial-highlight) {
+  .video-panel-list:has(.tutorial-highlight),
+  .header-right:has(.tutorial-highlight),
+  .header-actions:has(.tutorial-highlight) {
     overflow: visible !important;
   }
 }

--- a/src/ui/tutorial.js
+++ b/src/ui/tutorial.js
@@ -112,7 +112,7 @@ const STEPS = [
   {
     id: 6, title: 'Deep Dive!',
     highlight: '.quiz-feedback-area',
-    positionHint: 'left',
+    positionHint: 'right',
     onEnter: 'openQuiz,enableAutoAdvance',
     message: () => {
       const touch = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
@@ -146,7 +146,7 @@ const STEPS = [
   },
   {
     id: 10, title: 'Exploring Domain-Specific Knowledge',
-    positionHint: 'left',
+    positionHint: 'right',
     advanceOn: 'answer',
     questionTarget: 2,
     dynamicMessage: true, // message set in renderCurrentStep based on selected domain

--- a/src/ui/tutorial.js
+++ b/src/ui/tutorial.js
@@ -112,7 +112,7 @@ const STEPS = [
   {
     id: 6, title: 'Deep Dive!',
     highlight: '.quiz-feedback-area',
-    positionHint: 'right',
+    positionHint: 'quiz-final',
     onEnter: 'openQuiz,enableAutoAdvance',
     message: () => {
       const touch = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
@@ -146,7 +146,7 @@ const STEPS = [
   },
   {
     id: 10, title: 'Exploring Domain-Specific Knowledge',
-    positionHint: 'right',
+    positionHint: 'quiz-final',
     advanceOn: 'answer',
     questionTarget: 2,
     dynamicMessage: true, // message set in renderCurrentStep based on selected domain

--- a/src/ui/tutorial.js
+++ b/src/ui/tutorial.js
@@ -1,5 +1,7 @@
 // Tutorial mode — state machine, modal rendering, step logic
 
+import { setCollectionEnabled } from '../collection/collector.js';
+
 const STORAGE_KEY = 'mapper-tutorial';
 const MODAL_MAX_WIDTH = 380;
 const MOBILE_BP = 480;
@@ -200,7 +202,13 @@ const STEPS = [
     advanceOn: 'click',
   },
   {
-    id: 15, title: 'Tutorial Complete!',
+    id: 15, title: 'Contribute to science!',
+    advanceOn: 'consent-choice',
+    onEnter: 'closeModals',
+    isConsent: true,
+  },
+  {
+    id: 16, title: 'Tutorial Complete!',
     advanceOn: 'click',
     onEnter: 'closeModals,showTutorialBtn',
     arrowTarget: '#tutorial-btn',
@@ -738,6 +746,11 @@ function renderCurrentStep() {
     message = buildDynamicMessage(stepDef);
   }
 
+  // Consent step — data collection opt-in/out
+  if (stepDef.isConsent) {
+    message = 'This demo is just the beginning! We are working towards new tools for democratizing education and helping <em>all</em> people achieve their learning goals and dreams.\n\nWould you consider sharing your (anonymized) quiz responses with us to help us improve our system? You can change your mind at any time by clicking the about button (<i class="fa-solid fa-circle-info" style="vertical-align:middle;margin:0 2px;font-size:0.9em;color:var(--color-text-muted,#64748b)"></i>) and toggling the switch.';
+  }
+
   // Completion step
   if (stepDef.isCompletion) {
     message = "You've finished the formal tutorial. You can continue answering questions to refine your map and expand your knowledge!\n\nReplay the tutorial any time using the <span style=\"display:inline-flex;align-items:center;justify-content:center;width:1.3em;height:1.3em;border-radius:50%;background:var(--color-text-muted,#64748b);color:#fff;font-size:0.85em;font-weight:600;vertical-align:text-bottom\">?</span> button near the top of the screen.";
@@ -754,9 +767,10 @@ function renderCurrentStep() {
     ? (resolveSubStep(stepDef, state.subStep)?.advanceOn || 'click')
     : (stepDef.advanceOn || 'click');
   const isFinish = !!stepDef.isCompletion;
-  const showNextBtn = advanceOn === 'click' || isFinish;
+  const isConsent = !!stepDef.isConsent;
+  const showNextBtn = (advanceOn === 'click' || isFinish) && !isConsent;
 
-  renderOverlay(highlight, title, message, showNextBtn, isFinish, arrowTarget, arrowSide, positionHint);
+  renderOverlay(highlight, title, message, showNextBtn, isFinish, arrowTarget, arrowSide, positionHint, isConsent);
   _currentHighlightSelector = highlight; // Set AFTER renderOverlay (which calls removeOverlay → clears it)
   startHighlightRefresh();
 }
@@ -1078,7 +1092,7 @@ function repositionArrow(arrow, targetEl, side) {
   arrow.style.left = `${left}px`;
 }
 
-function renderOverlay(highlightSelector, title, message, showNextBtn, isFinish, arrowTargetSelector, arrowSide = 'left', positionHint = null) {
+function renderOverlay(highlightSelector, title, message, showNextBtn, isFinish, arrowTargetSelector, arrowSide = 'left', positionHint = null, isConsent = false) {
   removeOverlay();
 
   // Overlay
@@ -1218,7 +1232,7 @@ function renderOverlay(highlightSelector, title, message, showNextBtn, isFinish,
     }
   }
 
-  buildModalDOM(modal, title, message, showNextBtn, isFinish);
+  buildModalDOM(modal, title, message, showNextBtn, isFinish, isConsent);
   makeDraggable(modal);
 
   document.body.appendChild(modal);
@@ -1265,7 +1279,7 @@ function renderOverlay(highlightSelector, title, message, showNextBtn, isFinish,
   });
 }
 
-function buildModalDOM(modal, title, message, showNextBtn, isFinish) {
+function buildModalDOM(modal, title, message, showNextBtn, isFinish, isConsent = false) {
   // Drag handle + dismiss
   const header = document.createElement('div');
   Object.assign(header.style, {
@@ -1310,6 +1324,35 @@ function buildModalDOM(modal, title, message, showNextBtn, isFinish) {
 
   // Skip link removed — dismiss button (×) in header serves the same purpose
 
+  if (isConsent) {
+    const helpBtn = document.createElement('button');
+    Object.assign(helpBtn.style, {
+      background: 'var(--color-primary, #00693e)', color: '#fff', border: 'none',
+      padding: '10px 24px', borderRadius: '8px', fontSize: '0.95em', cursor: 'pointer',
+      fontWeight: '600', width: '100%',
+    });
+    helpBtn.textContent = "I'd like to help!";
+    helpBtn.addEventListener('click', () => {
+      setCollectionEnabled(true);
+      advanceTutorial('consent-choice');
+    });
+    footer.appendChild(helpBtn);
+
+    const noBtn = document.createElement('button');
+    Object.assign(noBtn.style, {
+      background: 'transparent', color: 'var(--color-text-muted, #64748b)',
+      border: '1px solid var(--color-border, #e2e8f0)',
+      padding: '8px 20px', borderRadius: '8px', fontSize: '0.9em', cursor: 'pointer',
+      fontWeight: '500', width: '100%',
+    });
+    noBtn.textContent = 'No thanks';
+    noBtn.addEventListener('click', () => {
+      setCollectionEnabled(false);
+      advanceTutorial('consent-choice');
+    });
+    footer.appendChild(noBtn);
+  }
+
   if (showNextBtn) {
     const nextBtn = document.createElement('button');
     nextBtn.className = 'tutorial-next-btn';
@@ -1338,14 +1381,14 @@ function renderMarkdownLite(container, text) {
     }
     const p = document.createElement('p');
     Object.assign(p.style, { margin: '0.4em 0' });
-    // Simple *italic* and <span> rendering
-    const parts = line.split(/(\*[^*]+\*|<span[^>]*>.*?<\/span>)/g);
+    // Simple *italic* and inline HTML (<span>, <i>, <em>) rendering
+    const parts = line.split(/(\*[^*]+\*|<(?:span|i|em)[^>]*>.*?<\/(?:span|i|em)>)/g);
     for (const part of parts) {
       if (part.startsWith('*') && part.endsWith('*') && part.length > 2) {
         const em = document.createElement('em');
         em.textContent = part.slice(1, -1);
         p.appendChild(em);
-      } else if (part.startsWith('<span')) {
+      } else if (/^<(?:span|i|em)\b/.test(part)) {
         const temp = document.createElement('template');
         temp.innerHTML = part;
         p.appendChild(temp.content);


### PR DESCRIPTION
## Summary

- **GoatCounter analytics**: Cookie-free visitor tracking via lightweight script tag (context-lab.goatcounter.com)
- **Response collection**: Anonymized quiz responses encoded as tokens and sent to a Google Sheet via Google Apps Script every 10 responses, plus a beforeunload beacon for partial sessions
- **Tutorial consent step**: "Contribute to science!" modal at end of tutorial lets users opt in/out
- **About modal toggle**: Data collection disclosure text with persistent opt-out switch
- **Offline decoder**: `scripts/decode-tokens.js` decodes collected tokens to CSV/JSON with per-question domain derivation
- **Citation update**: Updated to published Nature Communications 17:2055 DOI
- **Tutorial positioning fixes**: Deep Dive/Exploring Domain modals positioned left of quiz panel; header button highlights now dim full page correctly

Collection is **off by default** — users opt in via the tutorial or About modal. No PII is collected (tokens contain only question indices and answer correctness). Feature-flagged via `CONFIG.ENABLED` and `ENDPOINT_URL`.

## Test plan

- [x] Unit tests pass (110/110, Vitest)
- [x] GoatCounter snippet loads without errors (skips localhost correctly)
- [x] Response collection verified end-to-end: 10-question token appears in Google Sheet
- [x] Beforeunload beacon verified: partial session (11 responses) captured via fetch keepalive
- [x] Token round-trip fidelity: 100% (encode in browser → decode via script → all fields match)
- [x] Tutorial consent step: "I'd like to help!" enables collection, "No thanks" disables it
- [x] About modal toggle: syncs with tutorial choice in real-time, persists across sessions
- [x] Opt-out verified: toggling off prevents all collection
- [x] Shared view guard: no collection when viewing ?t= URLs
- [x] Tutorial positioning verified via Playwright screenshots (steps 6, 11, 12, 13, 15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)